### PR TITLE
Add Google Tag Manager snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Brightlab - Agencia Digital Integral</title>
   <meta name="description" content="Brightlab es una agencia digital integral que combina datos, creatividad y tecnología para transformar marcas. Servicios: Growth Marketing, UX, Investigación, IA, CRM y más.">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P9RSK8GW');</script>
+  <!-- End Google Tag Manager -->
   <link rel="icon" href="https://cdn-icons-png.flaticon.com/512/3416/3416074.png" type="image/png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P9RSK8GW"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <canvas class="particles"></canvas>
 
   <div class="loader-container" id="loaderContainer">


### PR DESCRIPTION
### Motivation
- Habilitar Google Tag Manager para gestionar y medir eventos y etiquetas en el sitio.
- Asegurar que el snippet se cargue de forma asíncrona y registre el inicio de GTM lo antes posible.
- Incluir un fallback para usuarios con JavaScript deshabilitado.

### Description
- Se añadió el script de Google Tag Manager en el `head` de `index.html` usando el ID `GTM-P9RSK8GW`.
- Se añadió el `noscript` con el `iframe` justo después de abrir el `body` como fallback.
- Se actualizó el archivo `index.html` para incluir ambos fragmentos del snippet.

### Testing
- No se ejecutaron pruebas automáticas para este cambio de HTML estático.
- El cambio es puramente de marcado y no afecta lógica de servidor o pruebas unitarias.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a511caac832f8eeceddf77800fa3)