### PR TITLE
Quitar loader inicial y actualizar CTA a "Conversemos" con sección de booking

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,16 +26,6 @@
 
   <canvas class="particles" aria-hidden="true"></canvas>
 
-  <div class="loader-container" id="loaderContainer" aria-live="polite">
-    <div class="loader-content">
-      <div class="loader-gears" aria-hidden="true">
-        <i class="fas fa-cog fa-spin"></i>
-        <i class="fas fa-cog fa-spin"></i>
-        <i class="fas fa-cog fa-spin"></i>
-      </div>
-      <p class="loader-text">Activando tu equipo digital de crecimiento...</p>
-    </div>
-  </div>
 
   <header class="hero fade-in-up" id="mainHero">
     <span class="eyebrow">Agencia digital integral</span>
@@ -44,7 +34,7 @@
     <p class="hero-slogan">Datos. Diseño. Impacto real.</p>
     <div class="hero-cta">
       <a class="btn-primary" href="#servicios">Ver servicios</a>
-      <button class="btn-secondary" id="contactBtn" aria-label="Abrir formulario de contacto">Hablemos</button>
+      <a class="btn-secondary" href="#booking" aria-label="Ir a agenda de reunión">Conversemos</a>
     </div>
   </header>
 
@@ -175,6 +165,14 @@
         </article>
       </div>
     </section>
+
+    <section id="booking" class="services-section fade-in-up" aria-label="Agenda una reunión">
+      <div class="section-heading">
+        <h2>Agenda una reunión con Brightlab</h2>
+        <p>Selecciona tu horario disponible y conversemos sobre tus objetivos.</p>
+      </div>
+      <iframe src='https://outlook.office.com/book/AgendaunareuninconBrightlab@brightlab.pe/?ismsaljsauthenabled' width='100%' height='700' scrolling='yes' style='border:0'></iframe>
+    </section>
   </main>
 
   <footer class="footer fade-in-up">
@@ -186,20 +184,6 @@
     <p>¿Tienes un reto digital? Escríbenos a <a href="mailto:hola@brightlab.pe">hola@brightlab.pe</a></p>
   </footer>
 
-  <div id="formModal" aria-label="Formulario de contacto" role="dialog" aria-modal="true" aria-hidden="true">
-    <div class="modal-card">
-      <button onclick="cerrarModal()" class="close-modal" aria-label="Cerrar formulario">&times;</button>
-      <h2>Contáctanos</h2>
-      <p>Cuéntanos tu objetivo y te responderemos en menos de 24 horas hábiles.</p>
-      <form action="https://formspree.io/f/xqaplrvd" method="POST">
-        <label for="email">Tu correo</label>
-        <input id="email" type="email" name="email" required>
-        <label for="message">Tu mensaje</label>
-        <textarea id="message" name="message" rows="4" required></textarea>
-        <button type="submit">Enviar</button>
-      </form>
-    </div>
-  </div>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,42 +1,7 @@
 window.addEventListener('load', () => {
-  setTimeout(() => {
-    const loader = document.getElementById('loaderContainer');
-    loader.classList.add('hidden');
-
-    setTimeout(() => {
-      loader.style.display = 'none';
-      document.querySelectorAll('.fade-in-up').forEach((element) => {
-        element.classList.add('visible');
-      });
-    }, 700);
-  }, 1200);
-});
-
-const contactBtn = document.getElementById('contactBtn');
-const modal = document.getElementById('formModal');
-
-contactBtn.addEventListener('click', () => {
-  modal.classList.add('show');
-  modal.setAttribute('aria-hidden', 'false');
-});
-
-function cerrarModal() {
-  modal.classList.remove('show');
-  modal.setAttribute('aria-hidden', 'true');
-}
-
-window.cerrarModal = cerrarModal;
-
-modal.addEventListener('click', (event) => {
-  if (event.target === modal) {
-    cerrarModal();
-  }
-});
-
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && modal.classList.contains('show')) {
-    cerrarModal();
-  }
+  document.querySelectorAll('.fade-in-up').forEach((element) => {
+    element.classList.add('visible');
+  });
 });
 
 const tabs = Array.from(document.querySelectorAll('.tab-btn'));


### PR DESCRIPTION
### Motivation
- Mostrar el contenido de la web directamente al cargar eliminando el overlay de loader con engranajes para mejorar la experiencia de usuario y evitar pasos extra.
- Reemplazar el CTA secundario `Hablemos` por `Conversemos` y dirigirlo al flujo de agendamiento para facilitar que los usuarios reserven una reunión.
- Incluir el iframe de Outlook Booking proporcionado para que la agenda esté embebida en la página.

### Description
- Eliminé el bloque HTML del loader/overlay (engranajes) en `index.html` para que el `header` y el contenido principal sean visibles de inmediato.
- Reemplacé el botón de contacto en el `header` por un enlace: `Hablemos` -> `Conversemos` que apunta a `#booking` en `index.html`.
- Añadí la sección `booking` en `index.html` que contiene el iframe de Outlook Booking con la URL proporcionada y altura `700` para mostrar la agenda.
- Limpié `script.js` eliminando la lógica relacionada con el loader y el modal de contacto y mantuve la inicialización de animaciones, tabs y partículas.

### Testing
- Ejecuté `git diff --check` como verificación de cambios estáticos y no reportó errores (ok).
- Levanté un servidor local con `python3 -m http.server 4173` y verifiqué que la página respondía (ok).
- Corrí un script de Playwright que navegó a `http://127.0.0.1:4173` y generó una captura de pantalla para validación visual, guardada en `artifacts/brightlab-updated.png` (ok).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b419dd8ba8832fac7ebbc7bf743bce)