### PR TITLE
Move booking to dedicated /contactanos page and open agenda in new tab

### DIFF
--- a/contactanos/index.html
+++ b/contactanos/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Brightlab | Agenda una reunión</title>
+  <meta name="description" content="Agenda una reunión con Brightlab usando nuestra página de reservas." />
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      background: #15182d;
+      color: #f5f7ff;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+
+    .topbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.9rem 1rem;
+      border-bottom: 1px solid rgba(255,255,255,0.14);
+      background: rgba(14, 17, 36, 0.92);
+      position: sticky;
+      top: 0;
+      z-index: 5;
+    }
+
+    .topbar h1 {
+      margin: 0;
+      font-size: clamp(1rem, 2vw, 1.3rem);
+    }
+
+    .actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      border-radius: 999px;
+      padding: 0.6rem 0.95rem;
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 0.9rem;
+      border: 0;
+    }
+
+    .btn-home {
+      background: #cfb6ff;
+      color: #1b1f38;
+    }
+
+    .btn-outlook {
+      background: #d7ff7b;
+      color: #1b1f38;
+    }
+
+    iframe {
+      width: 100%;
+      height: calc(100vh - 70px);
+      border: 0;
+      background: white;
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <h1>Agenda una reunión con Brightlab</h1>
+    <div class="actions">
+      <a class="btn btn-home" href="/">Volver al inicio</a>
+      <a class="btn btn-outlook" href="https://outlook.office.com/book/AgendaunareuninconBrightlab@brightlab.pe/?ismsaljsauthenabled" target="_blank" rel="noopener noreferrer">Abrir en Outlook</a>
+    </div>
+  </header>
+
+  <iframe src="https://outlook.office.com/book/AgendaunareuninconBrightlab@brightlab.pe/?ismsaljsauthenabled" title="Agenda Brightlab" loading="lazy"></iframe>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <p class="hero-slogan">Datos. Diseño. Impacto real.</p>
     <div class="hero-cta">
       <a class="btn-primary" href="#servicios">Ver servicios</a>
-      <a class="btn-secondary" href="#booking" aria-label="Ir a agenda de reunión">Conversemos</a>
+      <a class="btn-secondary" href="/contactanos/" aria-label="Abrir agenda de reunión" target="_blank" rel="noopener noreferrer">Conversemos</a>
     </div>
   </header>
 
@@ -169,9 +169,15 @@
     <section id="booking" class="services-section fade-in-up" aria-label="Agenda una reunión">
       <div class="section-heading">
         <h2>Agenda una reunión con Brightlab</h2>
-        <p>Selecciona tu horario disponible y conversemos sobre tus objetivos.</p>
+        <p>Para darte una mejor experiencia, abrimos la agenda en una vista dedicada.</p>
       </div>
-      <iframe src='https://outlook.office.com/book/AgendaunareuninconBrightlab@brightlab.pe/?ismsaljsauthenabled' width='100%' height='700' scrolling='yes' style='border:0'></iframe>
+      <div class="booking-card">
+        <p>Haz clic para abrir el calendario en una nueva pestaña o en la página <strong>/contactanos</strong>.</p>
+        <div class="booking-actions">
+          <a class="btn-primary" href="/contactanos/" target="_blank" rel="noopener noreferrer">Abrir agenda</a>
+          <a class="btn-secondary" href="/contactanos/">Ir a brightlab/contactanos</a>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -94,6 +94,8 @@ h1 {
   font-weight: 700;
   cursor: pointer;
   font-size: 0.95rem;
+  display: inline-block;
+  text-decoration: none;
 }
 
 .btn-primary {
@@ -403,4 +405,25 @@ a {
   .tab-btn {
     font-size: 0.88rem;
   }
+}
+
+.booking-card {
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.booking-card p {
+  margin-top: 0;
+  color: #e7e9f5;
+}
+
+.booking-actions {
+  display: flex;
+  gap: 0.8rem;
+  justify-content: center;
+  flex-wrap: wrap;
 }


### PR DESCRIPTION
### Motivation
- La agenda de Outlook estaba embebida en la home y se pidió que al hacer click abra la agenda en otra vista o ventana para mejorar la experiencia y evitar un iframe directo en la página principal.

### Description
- Cambié el CTA principal "Conversemos" para que abra `/contactanos/` en una nueva pestaña usando `target="_blank"` y atributos de seguridad `rel="noopener noreferrer"` en `index.html`.
- Reemplacé el iframe embebido en la sección de booking de la home por una tarjeta de reserva con CTAs que dirigen a `/contactanos/` en `index.html` y añadí estilos asociados en `style.css` para que los enlaces se vean como botones y para la nueva tarjeta `.booking-card`.
- Añadí `contactanos/index.html` como página dedicada que contiene una barra superior con acciones (volver al inicio / abrir en Outlook) y un iframe full-screen al enlace de reserva de Outlook.

### Testing
- Levanté un servidor local con `python -m http.server 4173` y verifiqué que la web respondiera correctamente; la comprobación del servidor fue exitosa.
- Ejecuté un script de Playwright para navegar a `/` y `/contactanos/` y generé capturas en `artifacts/home-booking-update.png` y `artifacts/contactanos-page.png`, las cuales se crearon correctamente y confirman que ambas rutas cargan la vista esperada.
- Se validó visualmente que los CTAs funcionan y que el iframe sólo existe en la ruta dedicada `/contactanos/` mediante las capturas generadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41c61ba08832f9c040b32d1491eb7)