### PR TITLE
Replace loader and contact modal with booking iframe; simplify load behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,16 +26,6 @@
 
   <canvas class="particles" aria-hidden="true"></canvas>
 
-  <div class="loader-container" id="loaderContainer" aria-live="polite">
-    <div class="loader-content">
-      <div class="loader-gears" aria-hidden="true">
-        <i class="fas fa-cog fa-spin"></i>
-        <i class="fas fa-cog fa-spin"></i>
-        <i class="fas fa-cog fa-spin"></i>
-      </div>
-      <p class="loader-text">Activando tu equipo digital de crecimiento...</p>
-    </div>
-  </div>
 
   <header class="hero fade-in-up" id="mainHero">
     <span class="eyebrow">Agencia digital integral</span>
@@ -44,7 +34,7 @@
     <p class="hero-slogan">Datos. Diseño. Impacto real.</p>
     <div class="hero-cta">
       <a class="btn-primary" href="#servicios">Ver servicios</a>
-      <button class="btn-secondary" id="contactBtn" aria-label="Abrir formulario de contacto">Hablemos</button>
+      <button class="btn-secondary" id="bookingBtn" aria-label="Abrir sección de booking">Conversemos</button>
     </div>
   </header>
 
@@ -175,6 +165,7 @@
         </article>
       </div>
     </section>
+
   </main>
 
   <footer class="footer fade-in-up">
@@ -186,20 +177,14 @@
     <p>¿Tienes un reto digital? Escríbenos a <a href="mailto:hola@brightlab.pe">hola@brightlab.pe</a></p>
   </footer>
 
-  <div id="formModal" aria-label="Formulario de contacto" role="dialog" aria-modal="true" aria-hidden="true">
-    <div class="modal-card">
-      <button onclick="cerrarModal()" class="close-modal" aria-label="Cerrar formulario">&times;</button>
-      <h2>Contáctanos</h2>
-      <p>Cuéntanos tu objetivo y te responderemos en menos de 24 horas hábiles.</p>
-      <form action="https://formspree.io/f/xqaplrvd" method="POST">
-        <label for="email">Tu correo</label>
-        <input id="email" type="email" name="email" required>
-        <label for="message">Tu mensaje</label>
-        <textarea id="message" name="message" rows="4" required></textarea>
-        <button type="submit">Enviar</button>
-      </form>
+
+
+  <section id="bookingSection" class="booking-section" aria-label="Sección de booking" aria-hidden="true">
+    <div class="booking-header">
+      <button class="btn-secondary" id="backBtn" aria-label="Volver atrás">Volver atrás</button>
     </div>
-  </div>
+    <iframe src='https://outlook.office.com/book/AgendaunareuninconBrightlab@brightlab.pe/?ismsaljsauthenabled' width='100%' height='100%' scrolling='yes' style='border:0' title='Agenda una reunión con Brightlab'></iframe>
+  </section>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,43 +1,28 @@
 window.addEventListener('load', () => {
-  setTimeout(() => {
-    const loader = document.getElementById('loaderContainer');
-    loader.classList.add('hidden');
-
-    setTimeout(() => {
-      loader.style.display = 'none';
-      document.querySelectorAll('.fade-in-up').forEach((element) => {
-        element.classList.add('visible');
-      });
-    }, 700);
-  }, 1200);
+  document.querySelectorAll('.fade-in-up').forEach((element) => {
+    element.classList.add('visible');
+  });
 });
 
-const contactBtn = document.getElementById('contactBtn');
-const modal = document.getElementById('formModal');
 
-contactBtn.addEventListener('click', () => {
-  modal.classList.add('show');
-  modal.setAttribute('aria-hidden', 'false');
-});
+const bookingBtn = document.getElementById('bookingBtn');
+const backBtn = document.getElementById('backBtn');
+const bookingSection = document.getElementById('bookingSection');
 
-function cerrarModal() {
-  modal.classList.remove('show');
-  modal.setAttribute('aria-hidden', 'true');
+function openBooking() {
+  bookingSection.classList.add('show');
+  bookingSection.setAttribute('aria-hidden', 'false');
 }
 
-window.cerrarModal = cerrarModal;
+function closeBooking() {
+  bookingSection.classList.remove('show');
+  bookingSection.setAttribute('aria-hidden', 'true');
+}
 
-modal.addEventListener('click', (event) => {
-  if (event.target === modal) {
-    cerrarModal();
-  }
-});
-
-document.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape' && modal.classList.contains('show')) {
-    cerrarModal();
-  }
-});
+if (bookingBtn && backBtn && bookingSection) {
+  bookingBtn.addEventListener('click', openBooking);
+  backBtn.addEventListener('click', closeBooking);
+}
 
 const tabs = Array.from(document.querySelectorAll('.tab-btn'));
 const panels = Array.from(document.querySelectorAll('.tab-panel'));

--- a/style.css
+++ b/style.css
@@ -404,3 +404,27 @@ a {
     font-size: 0.88rem;
   }
 }
+
+.booking-section {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.booking-section.show {
+  display: block;
+}
+
+.booking-header {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.booking-section iframe {
+  width: 100%;
+  height: calc(100vh - 4.5rem);
+}


### PR DESCRIPTION
### Motivation

- Replace the previous loader and contact-modal flow with an embedded booking experience to streamline scheduling and surface content faster.
- Remove the timed loader to make the hero and page sections visible immediately on load for better perceived performance.
- Provide accessible open/close controls for the new booking flow while preserving the services tab UI.

### Description

- Removed the loader container and the contact `formModal` from `index.html`, renamed `contactBtn` to `bookingBtn`, and added a `bookingSection` that embeds an Outlook booking `iframe` and a `backBtn` to close it.
- Simplified the load behaviour in `script.js` to immediately add `visible` to `.fade-in-up` elements on `load`, removed the modal-related functions and escape-key handler, and added `openBooking`/`closeBooking` handlers wired to `bookingBtn` and `backBtn` when present.
- Added styles for `.booking-section` and related layout in `style.css` to control the full-screen booking iframe and the show/hide state via the `.show` class.
- Updated ARIA labels and button text to reflect the new booking flow and preserved the existing tab mechanics and accessibility attributes.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b419dd8ba8832fac7ebbc7bf743bce)