### PR TITLE
Remove homepage booking section and Outlook button on contact page

### DIFF
--- a/contactanos/index.html
+++ b/contactanos/index.html
@@ -60,11 +60,6 @@
       color: #1b1f38;
     }
 
-    .btn-outlook {
-      background: #d7ff7b;
-      color: #1b1f38;
-    }
-
     iframe {
       width: 100%;
       height: calc(100vh - 70px);
@@ -78,7 +73,6 @@
     <h1>Agenda una reunión con Brightlab</h1>
     <div class="actions">
       <a class="btn btn-home" href="/">Volver al inicio</a>
-      <a class="btn btn-outlook" href="https://outlook.office.com/book/AgendaunareuninconBrightlab@brightlab.pe/?ismsaljsauthenabled" target="_blank" rel="noopener noreferrer">Abrir en Outlook</a>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -166,19 +166,6 @@
       </div>
     </section>
 
-    <section id="booking" class="services-section fade-in-up" aria-label="Agenda una reunión">
-      <div class="section-heading">
-        <h2>Agenda una reunión con Brightlab</h2>
-        <p>Para darte una mejor experiencia, abrimos la agenda en una vista dedicada.</p>
-      </div>
-      <div class="booking-card">
-        <p>Haz clic para abrir el calendario en una nueva pestaña o en la página <strong>/contactanos</strong>.</p>
-        <div class="booking-actions">
-          <a class="btn-primary" href="/contactanos/" target="_blank" rel="noopener noreferrer">Abrir agenda</a>
-          <a class="btn-secondary" href="/contactanos/">Ir a brightlab/contactanos</a>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer class="footer fade-in-up">


### PR DESCRIPTION
### Motivation
- Remove duplicated meeting CTA on the homepage and simplify the booking flow so the contact booking page is the single source of truth. 
- Keep the contact page header minimal when opened from the booking flow by leaving only the back button and removing the external Outlook action.

### Description
- Removed the `#booking` section from `index.html` so the homepage no longer repeats the meeting CTA. 
- Removed the `.btn-outlook` CSS rule and the `Abrir en Outlook` link from `contactanos/index.html`, leaving only the `Volver al inicio` button in the header. 
- Left the booking `iframe` in `contactanos/index.html` intact so the dedicated booking view still loads the Outlook calendar.

### Testing
- Verified file changes and context with `nl -ba index.html` and `nl -ba contactanos/index.html`, which show the removed booking block and removed Outlook button CSS/markup. (succeeded)
- Checked repository status with `git status --short` to confirm modified files are staged for review. (succeeded)
- Started a local static server with `python -m http.server` and attempted to capture screenshots via Playwright, but the browser failed to start due to a Chromium `SIGSEGV` crash in this environment, so automated visual checks could not complete. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b420a51034832f9f2e707e510d1818)