### PR TITLE
Add Brightlab favicon and use local asset for site pages

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Logo Brightlab</title>
+  <rect width="64" height="64" rx="8" fill="#0f1230"/>
+  <g fill="#c9f774">
+    <ellipse cx="32" cy="26" rx="16" ry="13" transform="rotate(-20 32 26)"/>
+    <ellipse cx="36" cy="23" rx="8.2" ry="5.2" transform="rotate(-20 36 23)" fill="#0f1230"/>
+    <path d="M18 40c4 4 9 6 14 6s10-2 14-6l3 4c-5 5-11 8-17 8s-12-3-17-8z"/>
+    <path d="M27 52h10l3 8H24z"/>
+  </g>
+</svg>

--- a/contactanos/index.html
+++ b/contactanos/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Brightlab | Agenda una reunión</title>
   <meta name="description" content="Agenda una reunión con Brightlab usando nuestra página de reservas." />
+  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
   <style>
     :root {
       color-scheme: dark;

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P9RSK8GW');</script>
   <!-- End Google Tag Manager -->
-  <link rel="icon" href="https://cdn-icons-png.flaticon.com/512/3416/3416074.png" type="image/png" />
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet" />


### PR DESCRIPTION
### Motivation
- Garantizar que la pestaña del navegador muestre el logo de la compañía de forma consistente en las páginas del sitio usando un favicon local en lugar de un recurso externo.

### Description
- Añadí `assets/favicon.svg`, un SVG con la marca Brightlab para usar como favicon.
- Reemplacé la referencia externa a un icono en `index.html` por `assets/favicon.svg` usando el `link rel="icon"` local.
- Agregué `link rel="icon"` en `contactanos/index.html` apuntando a `../assets/favicon.svg` para mantener consistencia entre páginas.

### Testing
- Verifiqué la presencia de los enlaces de favicon con `rg -n "favicon|rel=\"icon\"" index.html contactanos/index.html assets/favicon.svg` y encontró las entradas esperadas (éxito).
- Serví el sitio localmente con `python -m http.server 4173` y realicé una captura de pantalla con Playwright para validar visualmente el cambio (éxito).
- Confirmé que el archivo `assets/favicon.svg` existe y contiene el SVG esperado mediante inspección de archivos (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b422695d54832fb9e93ce5e9769e71)