### PR TITLE
Apply Brightlab brand assets across header, hero, favicon, and footer

### DIFF
--- a/contactanos/index.html
+++ b/contactanos/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Brightlab | Agenda una reunión</title>
   <meta name="description" content="Agenda una reunión con Brightlab usando nuestra página de reservas." />
-  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="../brightlab_repo_upload_ready/public/assets/brand/isotype-favicon.png" type="image/png" />
   <style>
     :root {
       color-scheme: dark;
@@ -38,7 +38,12 @@
 
     .topbar h1 {
       margin: 0;
-      font-size: clamp(1rem, 2vw, 1.3rem);
+      line-height: 0;
+    }
+
+    .topbar h1 img {
+      display: block;
+      height: auto;
     }
 
     .actions {
@@ -71,7 +76,7 @@
 </head>
 <body>
   <header class="topbar">
-    <h1>Agenda una reunión con Brightlab</h1>
+    <h1><img src="../brightlab_repo_upload_ready/public/assets/brand/logo-transparent.png" alt="Brightlab" width="170" height="53" /></h1>
     <div class="actions">
       <a class="btn btn-home" href="/">Volver al inicio</a>
     </div>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P9RSK8GW');</script>
   <!-- End Google Tag Manager -->
-  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="brightlab_repo_upload_ready/public/assets/brand/isotype-favicon.png" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet" />
@@ -27,9 +27,17 @@
   <canvas class="particles" aria-hidden="true"></canvas>
 
 
+  <header class="site-header fade-in-up">
+    <a class="brand-lockup" href="/" aria-label="Brightlab inicio">
+      <img src="brightlab_repo_upload_ready/public/assets/brand/logo-transparent.png" alt="Brightlab" width="220" height="68" />
+    </a>
+    <a class="header-cta" href="/contactanos/" target="_blank" rel="noopener noreferrer">Agenda una reunión</a>
+  </header>
+
   <header class="hero fade-in-up" id="mainHero">
+    <img class="hero-isotype" src="brightlab_repo_upload_ready/public/assets/brand/isotype-primary.png" alt="Isotipo Brightlab" width="82" height="82" />
     <span class="eyebrow">Agencia digital integral</span>
-    <h1>Brightlab</h1>
+    <h1>Bright solutions for smart decisions</h1>
     <p class="hero-subtitle">Convertimos ideas en resultados medibles combinando estrategia, creatividad y tecnología.</p>
     <p class="hero-slogan">Datos. Diseño. Impacto real.</p>
     <div class="hero-cta">
@@ -169,6 +177,7 @@
   </main>
 
   <footer class="footer fade-in-up">
+    <img class="footer-logo" src="brightlab_repo_upload_ready/public/assets/brand/logo-transparent.png" alt="Brightlab" width="190" height="58" />
     <div class="social" aria-label="Redes sociales de Brightlab">
       <a href="https://facebook.com/brightlab.pe" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><i class="fab fa-facebook-square"></i></a>
       <a href="https://instagram.com/brightlab.pe" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><i class="fab fa-instagram"></i></a>

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ body {
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Roboto', 'Inter', sans-serif;
   background: linear-gradient(-45deg, var(--bg-1), var(--bg-2), var(--bg-3), var(--bg-2));
   background-size: 400% 400%;
   animation: gradientBG 25s ease infinite;
@@ -39,15 +39,49 @@ body {
 }
 
 main,
+.site-header,
 .hero,
 .footer {
   width: min(1120px, 92%);
   margin-inline: auto;
 }
 
+
+.site-header {
+  padding: 1.1rem 0 0.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand-lockup {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 10px;
+  background: rgba(21, 24, 45, 0.45);
+}
+
+.brand-lockup img, .footer-logo, .hero-isotype {
+  height: auto;
+  display: block;
+}
+
+.header-cta {
+  background: #d7ff7b;
+  color: #15182d;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+}
+
 .hero {
   padding: 5.5rem 0 2rem;
   text-align: center;
+  display: grid;
+  justify-items: center;
 }
 
 .eyebrow {
@@ -119,7 +153,7 @@ h1 {
 .stats article {
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 14px;
+  border-radius: 20px;
   box-shadow: var(--shadow);
   padding: 1rem;
   text-align: left;
@@ -167,7 +201,7 @@ h1 {
   border: 1px solid var(--card-border);
   background: rgba(21, 24, 45, 0.75);
   color: var(--text);
-  border-radius: 12px;
+  border-radius: 10px;
   padding: 0.75rem;
   text-align: left;
   cursor: pointer;
@@ -196,7 +230,7 @@ h1 {
   display: none;
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 18px;
+  border-radius: 20px;
   box-shadow: var(--shadow);
   padding: 1.5rem;
   animation: fadePanel 0.3s ease;
@@ -324,7 +358,7 @@ a {
 .modal-card {
   background: #1b2142;
   width: min(440px, 100%);
-  border-radius: 14px;
+  border-radius: 20px;
   border: 1px solid rgba(215, 255, 123, 0.25);
   padding: 1.4rem;
   position: relative;
@@ -410,7 +444,7 @@ a {
 .booking-card {
   background: var(--card);
   border: 1px solid var(--card-border);
-  border-radius: 18px;
+  border-radius: 20px;
   box-shadow: var(--shadow);
   padding: 1.5rem;
   text-align: center;
@@ -426,4 +460,10 @@ a {
   gap: 0.8rem;
   justify-content: center;
   flex-wrap: wrap;
+}
+
+.footer-logo { margin: 0 auto 0.9rem; }
+
+@media (max-width: 640px) {
+  .site-header { flex-direction: column; }
 }


### PR DESCRIPTION
### Motivation
- Brought the live site into alignment with the Brightlab brand guidance by using committed brand assets and palette tokens discovered in the repo (inspected `brightlab_repo_upload_ready/AGENTS.md`, `brightlab_repo_upload_ready/README_BRAND_ASSETS.md`, `brightlab_repo_upload_ready/docs/brand/BRIGHTLAB_BRAND_SUMMARY.md`, `brightlab_repo_upload_ready/docs/brand/assets-manifest.json`, and files under `brightlab_repo_upload_ready/public/assets/brand/`).
- The change's intent is to consistently surface the official logo/isotype and favicon on primary UI surfaces (header, hero, favicon, footer, and contact page) and to adjust site styles to match the brand's rounded, high-contrast aesthetic.
- Assumed the site serves static files from the repository root and therefore referenced the provided `brightlab_repo_upload_ready/public/assets/brand/` PNG assets from pages rather than modifying or moving original asset files.

### Description
- Updated `index.html` to use the official favicon `isotype-favicon.png`, added a `site-header` with the `logo-transparent.png` lockup, inserted `isotype-primary.png` in the hero, and replaced the hero title with the brand tagline.
- Updated `contactanos/index.html` to use the `isotype-favicon.png` and to show `logo-transparent.png` in the topbar instead of plain text.
- Updated `style.css` to add `.site-header`, `.brand-lockup`, `.header-cta`, `.hero-isotype`, and `.footer-logo` styles, to prefer `Roboto` fallback for body text, and to increase card/panel border radii to match brand rounding guidelines.
- No brand asset files were altered or deleted and PNG assets were preferred for the UI changes.

### Testing
- Inspected brand files and asset inventory using `rg --files` and `cat` commands, which completed successfully and confirmed available assets and guidance. 
- Validated modifications by printing and grepping modified files with `rg -n` for new class and asset references, which returned the expected matches. 
- Performed repository status and recorded changes with `git status --short` and committed the three modified files, and the commit operation completed successfully. 
- All automated commands executed during the rollout completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1087f00d7c832fbdb8184f37cc65b2)